### PR TITLE
[deps] migrate Californium/Scandium 2.0.0 -> 3.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>californium-core</artifactId>
-      <version>2.0.0</version>
+      <version>3.14.0</version>
     </dependency>
 
     <dependency>
         <groupId>org.eclipse.californium</groupId>
         <artifactId>scandium</artifactId>
-        <version>2.0.0</version>
+        <version>3.14.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/openthread/SecurityUtils.java
+++ b/src/main/java/com/google/openthread/SecurityUtils.java
@@ -54,6 +54,7 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -61,8 +62,11 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.security.auth.x500.X500Principal;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1String;
@@ -113,14 +117,25 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.bouncycastle.util.Selector;
 import org.bouncycastle.util.Store;
+import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.config.UdpConfig;
 import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConfig;
+import org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateMessage;
 import org.eclipse.californium.scandium.dtls.CertificateType;
-import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.CertificateVerificationResult;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
-import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
+import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
  * Provides common security-related definitions and functionalities.
@@ -139,6 +154,11 @@ public class SecurityUtils {
 
   static {
     BouncyCastleInitializer.init();
+    // Register the Californium 3.x configuration modules so that
+    // Configuration.createStandardWithoutFile() knows the CoAP/DTLS/UDP definitions.
+    CoapConfig.register();
+    DtlsConfig.register();
+    UdpConfig.register();
     try {
       certFactory = CertificateFactory.getInstance("X.509");
     } catch (CertificateException ex) {
@@ -563,20 +583,44 @@ public class SecurityUtils {
     }
   }
 
-  public static final class DoNothingVerifier implements CertificateVerifier {
+  public static final class DoNothingVerifier implements NewAdvancedCertificateVerifier {
 
     public DoNothingVerifier(X509Certificate[] rootCertificates) {
       this.rootCertificates = rootCertificates;
     }
 
     @Override
-    public void verifyCertificate(CertificateMessage message, DTLSSession session) {
-      // We do nothing to accept the peer
+    public List<CertificateType> getSupportedCertificateTypes() {
+      return Collections.singletonList(CertificateType.X_509);
     }
 
     @Override
-    public X509Certificate[] getAcceptedIssuers() {
-      return rootCertificates;
+    public CertificateVerificationResult verifyCertificate(
+        ConnectionId cid,
+        ServerNames serverName,
+        InetSocketAddress remotePeer,
+        boolean clientUsage,
+        boolean verifySubject,
+        boolean truncateCertificatePath,
+        CertificateMessage message) {
+      // We do nothing to accept the peer
+      return new CertificateVerificationResult(cid, message.getCertificateChain(), null);
+    }
+
+    @Override
+    public List<X500Principal> getAcceptedIssuers() {
+      List<X500Principal> res = new ArrayList<>();
+      if (rootCertificates != null) {
+        for (X509Certificate cert : rootCertificates) {
+          res.add(cert.getSubjectX500Principal());
+        }
+      }
+      return res;
+    }
+
+    @Override
+    public void setResultHandler(HandshakeResultHandler resultHandler) {
+      // Verification is performed synchronously, so no asynchronous result handler is needed.
     }
 
     private X509Certificate[] rootCertificates;
@@ -586,7 +630,7 @@ public class SecurityUtils {
       X509Certificate[] trustAnchors,
       PrivateKey privateKey,
       X509Certificate[] certificateChain,
-      CertificateVerifier verifier,
+      NewAdvancedCertificateVerifier verifier,
       boolean isSniEnabled) {
     return genCoapEndPoint(
         -1, trustAnchors, privateKey, certificateChain, verifier, false, isSniEnabled);
@@ -597,7 +641,7 @@ public class SecurityUtils {
       X509Certificate[] trustAnchors,
       PrivateKey privateKey,
       X509Certificate[] certificateChain,
-      CertificateVerifier verifier) {
+      NewAdvancedCertificateVerifier verifier) {
     assert (port >= 0);
     return genCoapEndPoint(port, trustAnchors, privateKey, certificateChain, verifier, true, true);
   }
@@ -607,53 +651,65 @@ public class SecurityUtils {
       X509Certificate[] trustAnchors,
       PrivateKey privateKey,
       X509Certificate[] certificateChain,
-      CertificateVerifier verifier,
+      NewAdvancedCertificateVerifier verifier,
       boolean isServerEndPoint,
       boolean isSniEnabled) {
-    DtlsConnectorConfig.Builder config = new DtlsConnectorConfig.Builder();
+    Configuration configuration = Configuration.createStandardWithoutFile();
 
     if (isServerEndPoint) {
-      config.setSupportedCipherSuites(
+      configuration.setAsList(
+          DtlsConfig.DTLS_CIPHER_SUITES,
           CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
           CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
           CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,
           CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM);
     } else {
-      config.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+      configuration.setAsList(
+          DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
     }
 
-    config.setRetransmissionTimeout(10 * 1000);
+    configuration.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 10, TimeUnit.SECONDS);
 
     // Set Max Fragment Length to 2^10 bytes.
-    config.setMaxFragmentLengthCode(2);
+    configuration.set(
+        DtlsConfig.DTLS_MAX_FRAGMENT_LENGTH, MaxFragmentLengthExtension.Length.BYTES_1024);
 
     // OpenThread CoAP doesn't handle fragments, so it still fails
-    config.setMaxTransmissionUnit(1024);
+    configuration.set(DtlsConfig.DTLS_MAX_TRANSMISSION_UNIT, 1024);
 
-    config.setSniEnabled(isSniEnabled);
+    configuration.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, isSniEnabled);
+    configuration.set(
+        DtlsConfig.DTLS_ROLE, port >= 0 ? DtlsRole.SERVER_ONLY : DtlsRole.CLIENT_ONLY);
+
+    DtlsConnectorConfig.Builder config = new DtlsConnectorConfig.Builder(configuration);
+
     if (port >= 0) {
       // Server
-      config.setServerOnly(true).setAddress(new InetSocketAddress(port));
-    } else {
-      // Client
-      config.setClientOnly();
+      config.setAddress(new InetSocketAddress(port));
     }
 
-    if (verifier != null) {
-      config.setCertificateVerifier(verifier);
+    // In Scandium 3.x the trust anchors are part of the certificate verifier. When an explicit
+    // verifier is supplied it is fully responsible for validation; otherwise fall back to a
+    // static verifier that validates the peer chain against the given trust anchors.
+    NewAdvancedCertificateVerifier certificateVerifier = verifier;
+    if (certificateVerifier == null && trustAnchors != null && trustAnchors.length > 0) {
+      certificateVerifier =
+          StaticNewAdvancedCertificateVerifier.builder()
+              .setTrustedCertificates(trustAnchors)
+              .build();
+    }
+    if (certificateVerifier != null) {
+      config.setAdvancedCertificateVerifier(certificateVerifier);
     }
 
-    if (trustAnchors != null) {
-      config.setTrustStore(trustAnchors);
-    }
-
-    List<CertificateType> types = new ArrayList<>();
-
-    types.add(CertificateType.X_509);
-    config.setIdentity(privateKey, certificateChain, types);
+    config.setCertificateIdentityProvider(
+        new SingleCertificateProvider(privateKey, certificateChain, CertificateType.X_509));
 
     DTLSConnector connector = new DTLSConnector(config.build());
-    return new CoapEndpoint.Builder().setConnector(connector).build();
+    return new CoapEndpoint.Builder()
+        .setConnector(connector)
+        .setConfiguration(configuration)
+        .build();
   }
 
   // As defined in 4.2.1.2 of RFC 5280, authority key identifier (subject key identifier of CA)

--- a/src/main/java/com/google/openthread/pledge/Pledge.java
+++ b/src/main/java/com/google/openthread/pledge/Pledge.java
@@ -94,7 +94,7 @@ import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.elements.exception.ConnectorException;
-import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -669,11 +669,19 @@ public final class Pledge extends CoapClient {
   }
 
   private void initEndpoint(
-      PrivateKey privateKey, X509Certificate[] certificateChain, CertificateVerifier verifier) {
+      PrivateKey privateKey,
+      X509Certificate[] certificateChain,
+      NewAdvancedCertificateVerifier verifier) {
     CoapEndpoint endpoint =
         SecurityUtils.genCoapClientEndPoint(
             new X509Certificate[]{}, privateKey, certificateChain, verifier, false);
     setEndpoint(endpoint);
+    // Californium's CoapClient pins the destination EndpointContext from the previous response
+    // to keep follow-up requests on the same DTLS session. When we swap the endpoint (e.g. for
+    // re-enrollment or reset) that pinned context refers to a session that no longer exists, and
+    // the strict context matcher would drop the next request. Clear it so the freshly created
+    // endpoint performs a new handshake.
+    setDestinationContext(null);
   }
 
   // We need a provisional DTLS session before requesting

--- a/src/main/java/com/google/openthread/pledge/PledgeCertificateVerifier.java
+++ b/src/main/java/com/google/openthread/pledge/PledgeCertificateVerifier.java
@@ -29,6 +29,7 @@
 package com.google.openthread.pledge;
 
 import com.google.openthread.brski.ConstantsBrski;
+import java.net.InetSocketAddress;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertificateException;
@@ -36,9 +37,11 @@ import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.security.auth.x500.X500Principal;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -47,12 +50,14 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
-import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
-import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.CertificateMessage;
-import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.CertificateVerificationResult;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.HandshakeException;
-import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * CertificateVerifier for the Pledge, to perform all actions with a Registrar such as BRSKI voucher
  * request, enrollment, re-enrollment, etc. Only valid for scope of contact with a Registrar.
  */
-public final class PledgeCertificateVerifier implements CertificateVerifier {
+public final class PledgeCertificateVerifier implements NewAdvancedCertificateVerifier {
 
   private static final Logger logger = LoggerFactory.getLogger(PledgeCertificateVerifier.class);
 
@@ -78,8 +83,19 @@ public final class PledgeCertificateVerifier implements CertificateVerifier {
   }
 
   @Override
-  public void verifyCertificate(CertificateMessage message, DTLSSession session)
-      throws HandshakeException {
+  public List<CertificateType> getSupportedCertificateTypes() {
+    return Collections.singletonList(CertificateType.X_509);
+  }
+
+  @Override
+  public CertificateVerificationResult verifyCertificate(
+      ConnectionId cid,
+      ServerNames serverName,
+      InetSocketAddress remotePeer,
+      boolean clientUsage,
+      boolean verifySubject,
+      boolean truncateCertificatePath,
+      CertificateMessage message) {
 
     // We save the provisionally accepted registrar certificate chain, it will be verified
     // later, after we get a pinned domain/Registrar certificate in the voucher.
@@ -87,10 +103,12 @@ public final class PledgeCertificateVerifier implements CertificateVerifier {
 
     // Check that it contains at least something to verify later.
     if (peerCertPath.getCertificates().isEmpty()) {
-      AlertMessage alert =
-          new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE, session.getPeer());
       peerAccepted = false;
-      throw new HandshakeException("No server certificates", alert);
+      AlertMessage alert =
+          new AlertMessage(
+              AlertMessage.AlertLevel.FATAL, AlertMessage.AlertDescription.BAD_CERTIFICATE);
+      return new CertificateVerificationResult(
+          cid, new HandshakeException("No server certificates", alert), null);
     }
 
     try {
@@ -128,7 +146,7 @@ public final class PledgeCertificateVerifier implements CertificateVerifier {
         params.setRevocationEnabled(false);
 
         CertPathValidator validator = CertPathValidator.getInstance("PKIX");
-        validator.validate(message.getCertificateChain(), params);
+        validator.validate(peerCertPath, params);
         logger.info("handshake - certificate validation succeeded");
       } else {
         // We do no verification here to provisionally accept registrar certificate.
@@ -139,25 +157,31 @@ public final class PledgeCertificateVerifier implements CertificateVerifier {
       peerAccepted = true;
     } catch (Exception e) {
       logger.error("handshake - certificate validation failed: " + e.getMessage(), e);
+      peerAccepted = false;
       AlertMessage alert =
           new AlertMessage(
-              AlertMessage.AlertLevel.FATAL,
-              AlertMessage.AlertDescription.BAD_CERTIFICATE,
-              session.getPeer());
-      peerAccepted = false;
-      throw new HandshakeException("Certificate chain could not be validated", alert, e);
+              AlertMessage.AlertLevel.FATAL, AlertMessage.AlertDescription.BAD_CERTIFICATE);
+      return new CertificateVerificationResult(
+          cid, new HandshakeException("Certificate chain could not be validated", alert, e), null);
     }
+
+    return new CertificateVerificationResult(cid, peerCertPath, null);
   }
 
   @Override
-  public X509Certificate[] getAcceptedIssuers() {
-    List<X509Certificate> res = new ArrayList<>();
+  public List<X500Principal> getAcceptedIssuers() {
+    List<X500Principal> res = new ArrayList<>();
     for (TrustAnchor ta : trustAnchors) {
       if (ta.getTrustedCert() != null) {
-        res.add(ta.getTrustedCert());
+        res.add(ta.getTrustedCert().getSubjectX500Principal());
       }
     }
-    return res.toArray(new X509Certificate[0]);
+    return res;
+  }
+
+  @Override
+  public void setResultHandler(HandshakeResultHandler resultHandler) {
+    // Verification is performed synchronously, so no asynchronous result handler is needed.
   }
 
   public void addTrustAnchor(TrustAnchor ta) {

--- a/src/main/java/com/google/openthread/registrar/Registrar.java
+++ b/src/main/java/com/google/openthread/registrar/Registrar.java
@@ -80,7 +80,7 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.exception.ConnectorException;
-import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -919,7 +919,7 @@ public final class Registrar extends CoapServer {
     List<X509Certificate> trustAnchors = new ArrayList<>(Arrays.asList(masaTrustAnchors));
     trustAnchors.add(getDomainCertificate());
 
-    CertificateVerifier verifier;
+    NewAdvancedCertificateVerifier verifier;
     if (this.masaTrustAnchors.length == 0) {
       verifier = new RegistrarCertificateVerifier(null); // trust all clients.
     } else {

--- a/src/main/java/com/google/openthread/registrar/RegistrarCertificateVerifier.java
+++ b/src/main/java/com/google/openthread/registrar/RegistrarCertificateVerifier.java
@@ -28,22 +28,31 @@
 
 package com.google.openthread.registrar;
 
+import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
+import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import javax.security.auth.x500.X500Principal;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
 import org.eclipse.californium.scandium.dtls.CertificateMessage;
-import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.CertificateVerificationResult;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.HandshakeException;
-import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class RegistrarCertificateVerifier implements CertificateVerifier {
+public final class RegistrarCertificateVerifier implements NewAdvancedCertificateVerifier {
 
   private static final Logger logger =
       LoggerFactory.getLogger(RegistrarCertificateVerifier.class);
@@ -70,20 +79,32 @@ public final class RegistrarCertificateVerifier implements CertificateVerifier {
   }
 
   @Override
-  public void verifyCertificate(CertificateMessage message, DTLSSession session)
-      throws HandshakeException {
+  public List<CertificateType> getSupportedCertificateTypes() {
+    return Collections.singletonList(CertificateType.X_509);
+  }
+
+  @Override
+  public CertificateVerificationResult verifyCertificate(
+      ConnectionId cid,
+      ServerNames serverName,
+      InetSocketAddress remotePeer,
+      boolean clientUsage,
+      boolean verifySubject,
+      boolean truncateCertificatePath,
+      CertificateMessage message) {
+    CertPath certChain = message.getCertificateChain();
+
     if (trustAnchors == null) {
       // Trust everyone
-      return;
+      return new CertificateVerificationResult(cid, certChain, null);
     }
     if (trustAnchors.isEmpty()) {
       // Trust no-one
       AlertMessage alert =
           new AlertMessage(
-              AlertMessage.AlertLevel.FATAL,
-              AlertMessage.AlertDescription.BAD_CERTIFICATE,
-              session.getPeer());
-      throw new HandshakeException("no client is trusted", alert);
+              AlertMessage.AlertLevel.FATAL, AlertMessage.AlertDescription.BAD_CERTIFICATE);
+      return new CertificateVerificationResult(
+          cid, new HandshakeException("no client is trusted", alert), null);
     }
 
     try {
@@ -91,26 +112,31 @@ public final class RegistrarCertificateVerifier implements CertificateVerifier {
       params.setRevocationEnabled(false);
 
       CertPathValidator validator = CertPathValidator.getInstance("PKIX");
-      validator.validate(message.getCertificateChain(), params);
+      validator.validate(certChain, params);
 
     } catch (GeneralSecurityException e) {
       logger.error("handshake - certificate validation failed: " + e.getMessage(), e);
       AlertMessage alert =
           new AlertMessage(
-              AlertMessage.AlertLevel.FATAL,
-              AlertMessage.AlertDescription.BAD_CERTIFICATE,
-              session.getPeer());
-      throw new HandshakeException("Certificate chain could not be validated", alert, e);
+              AlertMessage.AlertLevel.FATAL, AlertMessage.AlertDescription.BAD_CERTIFICATE);
+      return new CertificateVerificationResult(
+          cid, new HandshakeException("Certificate chain could not be validated", alert, e), null);
     }
     logger.info("handshake - certificate validation succeeded");
+    return new CertificateVerificationResult(cid, certChain, null);
   }
 
   @Override
-  public X509Certificate[] getAcceptedIssuers() {
-    // This is used in the CertificateRequest message; we set it to an empty array to include
+  public List<X500Principal> getAcceptedIssuers() {
+    // This is used in the CertificateRequest message; we set it to an empty list to include
     // no trusted anchor issuers in that message. Because we could have many MASA trust
     // anchors, there is risk of IP fragmentation. So we leave this empty as we don't
     // really need it.
-    return new X509Certificate[0];
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void setResultHandler(HandshakeResultHandler resultHandler) {
+    // Verification is performed synchronously, so no asynchronous result handler is needed.
   }
 }


### PR DESCRIPTION
Bump californium-core and scandium to 3.14.0 and adapt to the 3.x API.

Configuration system (SecurityUtils.genCoapEndPoint):
- DtlsConnectorConfig.Builder now takes a Configuration; per-setter calls (cipher suites, retransmission timeout, max fragment length, MTU, SNI, client/server role) moved to Configuration.set(DtlsConfig.*, ...)
- setIdentity(...) -> setCertificateIdentityProvider(SingleCertificateProvider)
- register CoapConfig/DtlsConfig/UdpConfig modules in the static initializer
- trust anchors now live in the verifier: the MASA-client case (trust anchors, no custom verifier) builds a StaticNewAdvancedCertificateVerifier

Certificate verifiers (Registrar-, Pledge-, DoNothingVerifier):
- migrate from the removed CertificateVerifier to NewAdvancedCertificateVerifier
- verifyCertificate now returns a CertificateVerificationResult instead of throwing; AlertMessage no longer carries a peer; getAcceptedIssuers() returns List<X500Principal>; add getSupportedCertificateTypes()/setResultHandler()
- trust model, provisional acceptance and CMC-RA EKU checks are unchanged

Pledge endpoint swap:
- 3.x CoapClient pins the prior response's EndpointContext for connection stickiness; on re-enroll/reset the pledge swaps its endpoint, leaving that context pointing at a dead DTLS session, which the strict context matcher drops (EndpointMismatchException: DTLS sending). Clear it via setDestinationContext(null) so the new endpoint performs a fresh handshake.