### PR TITLE
[logging] log all received requests, incl. unknown-path/invalid-method (#2)

### DIFF
--- a/src/main/java/com/google/openthread/masa/MASA.java
+++ b/src/main/java/com/google/openthread/masa/MASA.java
@@ -117,6 +117,28 @@ public final class MASA {
     }
   }
 
+  /**
+   * Logs every received HTTP request - including ones for unknown paths or with an unsupported
+   * method - before delegating to the actual resource handlers. For interop testing.
+   */
+  final class RequestLoggingHttpHandler implements HttpHandler {
+    private final HttpHandler next;
+
+    RequestLoggingHttpHandler(HttpHandler next) {
+      this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+      logger.info(
+          "received HTTP request: {} {} from {}",
+          exchange.getRequestMethod(),
+          exchange.getRequestURI(),
+          exchange.getSourceAddress());
+      next.handleRequest(exchange);
+    }
+  }
+
   final class RootResourceHttpHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -417,7 +439,7 @@ public final class MASA {
     httpServer =
         Undertow.builder()
             .addHttpsListener(listenPort, "::", httpSsl)
-            .setHandler(masaPathHandler)
+            .setHandler(new RequestLoggingHttpHandler(masaPathHandler))
             .build();
   }
 }

--- a/src/main/java/com/google/openthread/registrar/Registrar.java
+++ b/src/main/java/com/google/openthread/registrar/Registrar.java
@@ -931,6 +931,8 @@ public final class Registrar extends CoapServer {
     CoapEndpoint endpoint =
         SecurityUtils.genCoapServerEndPoint(
             listenPort, null, privateKey, certificateChain, verifier);
+    // Log every received request (incl. unknown-path / unsupported-method ones) for interop testing.
+    endpoint.addInterceptor(new RequestLoggingInterceptor());
     addEndpoint(endpoint);
   }
 

--- a/src/main/java/com/google/openthread/registrar/RequestLoggingInterceptor.java
+++ b/src/main/java/com/google/openthread/registrar/RequestLoggingInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Registrar Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.openthread.registrar;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptorAdapter;
+import org.eclipse.californium.elements.EndpointContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logs every incoming CoAP request at the endpoint, before it is routed to a resource. This
+ * includes requests for a non-existing resource path or with an unsupported method, which the
+ * resource tree would otherwise answer (4.04 / 4.05) without any log entry. Intended for interop
+ * testing, to make all received requests - including failing ones - visible.
+ */
+public final class RequestLoggingInterceptor extends MessageInterceptorAdapter {
+
+  private static final Logger logger = LoggerFactory.getLogger(RequestLoggingInterceptor.class);
+
+  @Override
+  public void receiveRequest(Request request) {
+    EndpointContext src = request.getSourceContext();
+    logger.info(
+        "received CoAP request: {} /{} from {}",
+        request.getCode(),
+        request.getOptions().getUriPathString(),
+        src == null ? "unknown" : src.getPeerAddress());
+  }
+}


### PR DESCRIPTION
For interop testing, log every incoming request before it is routed, so that requests for a non-existing resource path or with an unsupported method - previously answered 4.04/4.05 (CoAP) or 404 (HTTP) with no log entry - become visible.

- Registrar: RequestLoggingInterceptor (Californium MessageInterceptor) added to the server endpoint; logs method + Uri-Path + source for every received CoAP request, before routing.
- MASA: the Undertow PathHandler is wrapped in a RequestLoggingHttpHandler that logs method + URI + source for every received HTTP request, before routing.

Valid requests keep their existing in-handler payload dump (RequestDumper); this adds a uniform request-line log that also covers the failing ones.